### PR TITLE
Add validation for non-negative maxNumberOfRetries/delayBetweenRetries

### DIFF
--- a/src/main/java/com/evanlennick/retry4j/RetryConfig.java
+++ b/src/main/java/com/evanlennick/retry4j/RetryConfig.java
@@ -39,6 +39,10 @@ public class RetryConfig {
     }
 
     public void setMaxNumberOfTries(int maxNumberOfTries) {
+        if (maxNumberOfTries < 0) {
+            throw new IllegalArgumentException("Must be non-negative number.");
+        }
+
         this.maxNumberOfTries = maxNumberOfTries;
     }
 
@@ -47,6 +51,10 @@ public class RetryConfig {
     }
 
     public void setDelayBetweenRetries(Duration delayBetweenRetries) {
+        if (delayBetweenRetries.isNegative()) {
+            throw new IllegalArgumentException("Must be non-negative Duration.");
+        }
+
         this.delayBetweenRetries = delayBetweenRetries;
     }
 
@@ -60,31 +68,31 @@ public class RetryConfig {
 
     public static RetryConfig simpleFixedConfig() {
         RetryConfig config = new RetryConfig();
-        config.retryOnAnyException = true;
-        config.retryOnSpecificExceptions = new HashSet<>();
-        config.maxNumberOfTries = 5;
-        config.delayBetweenRetries = Duration.of(10, ChronoUnit.SECONDS);
-        config.backoffStrategy = new FixedBackoffStrategy();
+        config.setRetryOnAnyException(true);
+        config.setRetryOnSpecificExceptions(new HashSet<>());
+        config.setMaxNumberOfTries(5);
+        config.setDelayBetweenRetries(Duration.of(10, ChronoUnit.SECONDS));
+        config.setBackoffStrategy(new FixedBackoffStrategy());
         return config;
     }
 
     public static RetryConfig simpleExponentialConfig() {
         RetryConfig config = new RetryConfig();
-        config.retryOnAnyException = true;
-        config.retryOnSpecificExceptions = new HashSet<>();
-        config.maxNumberOfTries = 5;
-        config.delayBetweenRetries = Duration.of(5, ChronoUnit.SECONDS);
-        config.backoffStrategy = new ExponentialBackoffStrategy();
+        config.setRetryOnAnyException(true);
+        config.setRetryOnSpecificExceptions(new HashSet<>());
+        config.setMaxNumberOfTries(5);
+        config.setDelayBetweenRetries(Duration.of(5, ChronoUnit.SECONDS));
+        config.setBackoffStrategy(new ExponentialBackoffStrategy());
         return config;
     }
 
     public static RetryConfig simpleFibonacciConfig() {
         RetryConfig config = new RetryConfig();
-        config.retryOnAnyException = true;
-        config.retryOnSpecificExceptions = new HashSet<>();
-        config.maxNumberOfTries = 7;
-        config.delayBetweenRetries = Duration.of(7, ChronoUnit.SECONDS);
-        config.backoffStrategy = new FibonacciBackoffStrategy();
+        config.setRetryOnAnyException(true);
+        config.setRetryOnSpecificExceptions(new HashSet<>());
+        config.setMaxNumberOfTries(7);
+        config.setDelayBetweenRetries(Duration.of(7, ChronoUnit.SECONDS));
+        config.setBackoffStrategy(new FibonacciBackoffStrategy());
         return config;
     }
 

--- a/src/main/java/com/evanlennick/retry4j/RetryConfig.java
+++ b/src/main/java/com/evanlennick/retry4j/RetryConfig.java
@@ -40,7 +40,7 @@ public class RetryConfig {
 
     public void setMaxNumberOfTries(int maxNumberOfTries) {
         if (maxNumberOfTries < 0) {
-            throw new IllegalArgumentException("Must be non-negative number.");
+            throw new IllegalArgumentException("Must be a non-negative number.");
         }
 
         this.maxNumberOfTries = maxNumberOfTries;
@@ -52,7 +52,7 @@ public class RetryConfig {
 
     public void setDelayBetweenRetries(Duration delayBetweenRetries) {
         if (delayBetweenRetries.isNegative()) {
-            throw new IllegalArgumentException("Must be non-negative Duration.");
+            throw new IllegalArgumentException("Must be a non-negative Duration.");
         }
 
         this.delayBetweenRetries = delayBetweenRetries;

--- a/src/test/java/com/evanlennick/retry4j/RetryConfigTest.java
+++ b/src/test/java/com/evanlennick/retry4j/RetryConfigTest.java
@@ -1,0 +1,26 @@
+package com.evanlennick.retry4j;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+public class RetryConfigTest {
+    private RetryConfig config;
+
+    @BeforeMethod
+    public void setup() {
+        this.config = new RetryConfig();
+    }
+
+    @Test(expectedExceptions = {IllegalArgumentException.class})
+    public void shouldNotAllowNegativeDelayBetweenRetries() {
+        config.setDelayBetweenRetries(Duration.of(-1, ChronoUnit.SECONDS));
+    }
+
+    @Test(expectedExceptions = {IllegalArgumentException.class})
+    public void shouldNotAllowNegativeMaxNumberOfTries() {
+        config.setMaxNumberOfTries(-1);
+    }
+}


### PR DESCRIPTION
Thought I could tackle a few of the open issues you have on this. I also changed the simple configs in the `RetryConfig` class to use the setter methods rather than accessing the fields directly within the class. It may seem a bit odd but there is also another issue open for moving those into the `RetryConfigBuilder` class so they would need to use the setters at that point anyways. Thanks!