### PR TITLE
Update withDelayBetweenTries method signatures

### DIFF
--- a/src/main/java/com/evanlennick/retry4j/RetryConfigBuilder.java
+++ b/src/main/java/com/evanlennick/retry4j/RetryConfigBuilder.java
@@ -5,6 +5,7 @@ import com.evanlennick.retry4j.exception.InvalidRetryConfigException;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -85,13 +86,8 @@ public class RetryConfigBuilder {
         return this;
     }
 
-    public RetryConfigBuilder withDelayBetweenTries(int seconds) {
-        config.setDelayBetweenRetries(Duration.of(seconds, ChronoUnit.SECONDS));
-        return this;
-    }
-
-    public RetryConfigBuilder withDelayBetweenTries(long millis) {
-        config.setDelayBetweenRetries(Duration.of(millis, ChronoUnit.MILLIS));
+    public RetryConfigBuilder withDelayBetweenTries(long amount, TemporalUnit time) {
+        config.setDelayBetweenRetries(Duration.of(amount, time));
         return this;
     }
 

--- a/src/main/java/com/evanlennick/retry4j/RetryConfigBuilder.java
+++ b/src/main/java/com/evanlennick/retry4j/RetryConfigBuilder.java
@@ -5,7 +5,6 @@ import com.evanlennick.retry4j.exception.InvalidRetryConfigException;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -86,7 +85,7 @@ public class RetryConfigBuilder {
         return this;
     }
 
-    public RetryConfigBuilder withDelayBetweenTries(long amount, TemporalUnit time) {
+    public RetryConfigBuilder withDelayBetweenTries(long amount, ChronoUnit time) {
         config.setDelayBetweenRetries(Duration.of(amount, time));
         return this;
     }

--- a/src/test/java/com/evanlennick/retry4j/RetryConfigBuilderTest_Validation.java
+++ b/src/test/java/com/evanlennick/retry4j/RetryConfigBuilderTest_Validation.java
@@ -5,6 +5,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.net.ConnectException;
+import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.AssertJUnit.fail;
@@ -24,7 +25,7 @@ public class RetryConfigBuilderTest_Validation {
         try {
             retryConfigBuilder
                     .withMaxNumberOfTries(1)
-                    .withDelayBetweenTries(1)
+                    .withDelayBetweenTries(1, ChronoUnit.SECONDS)
                     .build();
             fail("Expected InvalidRetryConfigException but one wasn't thrown!");
         } catch(InvalidRetryConfigException e) {
@@ -38,7 +39,7 @@ public class RetryConfigBuilderTest_Validation {
         try {
             retryConfigBuilder
                     .withMaxNumberOfTries(1)
-                    .withDelayBetweenTries(1)
+                    .withDelayBetweenTries(1, ChronoUnit.SECONDS)
                     .withExponentialBackoff()
                     .withFibonacciBackoff()
                     .build();
@@ -67,7 +68,7 @@ public class RetryConfigBuilderTest_Validation {
     public void verifyNoMaxTriesThrowsException() {
         try {
             retryConfigBuilder
-                    .withDelayBetweenTries(1)
+                    .withDelayBetweenTries(1, ChronoUnit.SECONDS)
                     .withExponentialBackoff()
                     .build();
             fail("Expected InvalidRetryConfigException but one wasn't thrown!");
@@ -82,7 +83,7 @@ public class RetryConfigBuilderTest_Validation {
         try {
             retryConfigBuilder
                     .withMaxNumberOfTries(1)
-                    .withDelayBetweenTries(1)
+                    .withDelayBetweenTries(1, ChronoUnit.SECONDS)
                     .withExponentialBackoff()
                     .failOnAnyException()
                     .retryOnSpecificExceptions(ConnectException.class)

--- a/src/test/java/com/evanlennick/retry4j/RetryConfigBuilderTest_ValidationDisabled.java
+++ b/src/test/java/com/evanlennick/retry4j/RetryConfigBuilderTest_ValidationDisabled.java
@@ -64,7 +64,7 @@ public class RetryConfigBuilderTest_ValidationDisabled {
     @Test
     public void testSettingDurationBetweenTries_seconds() {
         RetryConfig config = retryConfigBuilder
-                .withDelayBetweenTries(5)
+                .withDelayBetweenTries(5, ChronoUnit.SECONDS)
                 .build();
 
         assertThat(config.getDelayBetweenRetries().toMillis()).isEqualTo(5000);
@@ -73,7 +73,7 @@ public class RetryConfigBuilderTest_ValidationDisabled {
     @Test
     public void testSettingDurationBetweenTries_millis() {
         RetryConfig config = retryConfigBuilder
-                .withDelayBetweenTries(5000L)
+                .withDelayBetweenTries(5, ChronoUnit.MILLIS)
                 .build();
 
         assertThat(config.getDelayBetweenRetries().toMillis()).isEqualTo(5000);

--- a/src/test/java/com/evanlennick/retry4j/RetryExecutorTest.java
+++ b/src/test/java/com/evanlennick/retry4j/RetryExecutorTest.java
@@ -5,6 +5,7 @@ import com.evanlennick.retry4j.exception.UnexpectedException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +27,7 @@ public class RetryExecutorTest {
 
         RetryConfig retryConfig = retryConfigBuilder
                 .withMaxNumberOfTries(5)
-                .withDelayBetweenTries(0)
+                .withDelayBetweenTries(0, ChronoUnit.SECONDS)
                 .withFixedBackoff()
                 .build();
 
@@ -43,7 +44,7 @@ public class RetryExecutorTest {
         RetryConfig retryConfig = retryConfigBuilder
                 .retryOnAnyException()
                 .withMaxNumberOfTries(1)
-                .withDelayBetweenTries(0)
+                .withDelayBetweenTries(0, ChronoUnit.SECONDS)
                 .withFixedBackoff()
                 .build();
 
@@ -59,7 +60,7 @@ public class RetryExecutorTest {
         RetryConfig retryConfig = retryConfigBuilder
                 .retryOnSpecificExceptions(IllegalArgumentException.class)
                 .withMaxNumberOfTries(1)
-                .withDelayBetweenTries(0)
+                .withDelayBetweenTries(0, ChronoUnit.SECONDS)
                 .withFixedBackoff()
                 .build();
 
@@ -75,7 +76,7 @@ public class RetryExecutorTest {
         RetryConfig retryConfig = retryConfigBuilder
                 .retryOnSpecificExceptions(UnsupportedOperationException.class)
                 .withMaxNumberOfTries(1)
-                .withDelayBetweenTries(0)
+                .withDelayBetweenTries(0, ChronoUnit.SECONDS)
                 .withFixedBackoff()
                 .build();
 
@@ -88,7 +89,7 @@ public class RetryExecutorTest {
 
         RetryConfig retryConfig = retryConfigBuilder
                 .withMaxNumberOfTries(5)
-                .withDelayBetweenTries(0)
+                .withDelayBetweenTries(0, ChronoUnit.SECONDS)
                 .withFixedBackoff()
                 .build();
 
@@ -107,7 +108,7 @@ public class RetryExecutorTest {
 
         RetryConfig retryConfig = retryConfigBuilder
                 .withMaxNumberOfTries(5)
-                .withDelayBetweenTries(0)
+                .withDelayBetweenTries(0, ChronoUnit.SECONDS)
                 .withFixedBackoff()
                 .build();
 
@@ -129,7 +130,7 @@ public class RetryExecutorTest {
 
         RetryConfig retryConfig = retryConfigBuilder
                 .withMaxNumberOfTries(1)
-                .withDelayBetweenTries(0)
+                .withDelayBetweenTries(0, ChronoUnit.SECONDS)
                 .build();
 
         CallResults results = new CallExecutor(retryConfig).execute(callable);

--- a/src/test/java/com/evanlennick/retry4j/listener/RetryListenerTest.java
+++ b/src/test/java/com/evanlennick/retry4j/listener/RetryListenerTest.java
@@ -7,6 +7,7 @@ import com.evanlennick.retry4j.RetryConfigBuilder;
 import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.testng.annotations.Test;
 
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Callable;
 
 public class RetryListenerTest {
@@ -18,7 +19,7 @@ public class RetryListenerTest {
 
         RetryConfig retryConfig = new RetryConfigBuilder(false)
                 .withMaxNumberOfTries(1)
-                .withDelayBetweenTries(0)
+                .withDelayBetweenTries(0, ChronoUnit.SECONDS)
                 .build();
 
         CallExecutor executor = new CallExecutor(retryConfig);
@@ -36,7 +37,7 @@ public class RetryListenerTest {
 
         RetryConfig retryConfig = new RetryConfigBuilder(false)
                 .withMaxNumberOfTries(1)
-                .withDelayBetweenTries(0)
+                .withDelayBetweenTries(0, ChronoUnit.SECONDS)
                 .build();
 
         CallExecutor executor = new CallExecutor(retryConfig);


### PR DESCRIPTION
Removed the `int` and `long` overloads in favor of keeping around the `Duration` one along with adding a `long amount, ChronoUnit unit` overload.