### PR TITLE
Fixed typo in README sample code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are several libraries that have similar capabilities this but I found them
     RetryConfig config = new RetryConfigBuilder()
             .retryOnSpecificExceptions(ConnectException.class)
             .withMaxNumberOfTries(10)
-            .withDelayBetweenTries(30, ChronoUnit.SECONDS))
+            .withDelayBetweenTries(30, ChronoUnit.SECONDS)
             .withExponentialBackoff()
             .build();
             


### PR DESCRIPTION
Just an annoying little extra parenthesis in the README.