### PR TITLE
Made CallExecutor generic.

### DIFF
--- a/src/test/java/com/evanlennick/retry4j/RetryExecutorTest.java
+++ b/src/test/java/com/evanlennick/retry4j/RetryExecutorTest.java
@@ -33,8 +33,10 @@ public class RetryExecutorTest {
                 .withFixedBackoff()
                 .build();
 
-        CallResults results = new CallExecutor(retryConfig).execute(callable);
+        CallResults<Boolean> results = new CallExecutor<Boolean>(retryConfig).execute(callable);
+        Boolean value = results.getResult();
         assertThat(results.wasSuccessful());
+        assertThat(value).isEqualTo(true);
     }
 
     @Test(expectedExceptions = {RetriesExhaustedException.class})


### PR DESCRIPTION
Added a generic type on the callable return type allows the result to be pulled out without a cast.