### PR TITLE
Supporting to match against exception's cause

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ RetryConfig config = new RetryConfigBuilder()
         .build();
 ```
 
+If you want the executor to continue to retry when encountered exception's cause is among a list of exceptions, then specify **retryOnCausedBy()** config option
+```java
+RetryConfig config = new RetryConfigBuilder()
+        .retryOnCausedBy()
+        .retryOnSpecificExceptions(ConnectException.class, TimeoutException.class)
+        .build();
+```
+
 If you want the executor to continue to retry on all encountered exceptions EXCEPT for a few specific ones, specify this using the **retryOnAnyExceptionExcluding()** config option. If this exception strategy is chosen, only the exceptions specified or their subclasses will interupt the executor and throw an **UnexpectedException**.
 
 ```java

--- a/src/main/java/com/evanlennick/retry4j/config/RetryConfig.java
+++ b/src/main/java/com/evanlennick/retry4j/config/RetryConfig.java
@@ -18,6 +18,7 @@ public class RetryConfig {
     private Object valueToRetryOn;
     private Boolean retryOnValue = false;
     private Function<Exception, Boolean> customRetryOnLogic;
+    private boolean retryOnCausedBy;
 
     public Object getValueToRetryOn() {
         return valueToRetryOn;
@@ -57,6 +58,14 @@ public class RetryConfig {
 
     public void setRetryOnAnyExceptionExcluding(Set<Class<? extends Exception>> retryOnAnyExceptionExcluding) {
         this.retryOnAnyExceptionExcluding = retryOnAnyExceptionExcluding;
+    }
+
+    public void setRetryOnCausedBy(boolean retryOnCausedBy){
+        this.retryOnCausedBy = retryOnCausedBy;
+    }
+
+    public boolean shouldRetryOnCausedBy() {
+        return retryOnCausedBy;
     }
 
     public Integer getMaxNumberOfTries() {

--- a/src/main/java/com/evanlennick/retry4j/config/RetryConfigBuilder.java
+++ b/src/main/java/com/evanlennick/retry4j/config/RetryConfigBuilder.java
@@ -23,6 +23,7 @@ public class RetryConfigBuilder {
     private boolean builtInExceptionStrategySpecified;
     private RetryConfig config;
     private boolean validationEnabled;
+    private boolean matchAgainstExceptionCause;
 
     public final static String MUST_SPECIFY_BACKOFF__ERROR_MSG
             = "Retry config must specify a backoff strategy!";
@@ -74,6 +75,11 @@ public class RetryConfigBuilder {
         config.setRetryOnSpecificExceptions(new HashSet<>());
 
         builtInExceptionStrategySpecified = true;
+        return this;
+    }
+
+    public RetryConfigBuilder retryOnCausedBy(){
+        config.setRetryOnCausedBy(true);
         return this;
     }
 

--- a/src/test/java/com/evanlennick/retry4j/CallExecutorTest_RetryOnCustomLogicTest.java
+++ b/src/test/java/com/evanlennick/retry4j/CallExecutorTest_RetryOnCustomLogicTest.java
@@ -83,17 +83,4 @@ public class CallExecutorTest_RetryOnCustomLogicTest {
                 });
     }
 
-    private class CustomTestException extends RuntimeException {
-
-        private int someValue;
-
-        public CustomTestException(String message, int someValue) {
-            super(message);
-            this.someValue = someValue;
-        }
-
-        public int getSomeValue() {
-            return someValue;
-        }
-    }
 }

--- a/src/test/java/com/evanlennick/retry4j/CustomTestException.java
+++ b/src/test/java/com/evanlennick/retry4j/CustomTestException.java
@@ -1,0 +1,15 @@
+package com.evanlennick.retry4j;
+
+class CustomTestException extends RuntimeException {
+
+    private int someValue;
+
+    public CustomTestException(String message, int someValue) {
+        super(message);
+        this.someValue = someValue;
+    }
+
+    public int getSomeValue() {
+        return someValue;
+    }
+}


### PR DESCRIPTION
Initial attempt at matching against a exception's cause. The initial attempt is a basic implementation. There are possibly some other scenarios left out.

- what if cause is not present; should we skip matching logic and continue?
- what if a matching cause is more than one level deep? should we match against a cause at any level?

Please suggest any improvements.