### PR TITLE
Add retryOnReturnValues and retryOnReturnValuesExcluding

### DIFF
--- a/src/main/java/com/evanlennick/retry4j/CallExecutor.java
+++ b/src/main/java/com/evanlennick/retry4j/CallExecutor.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -133,8 +134,8 @@ public class CallExecutor<T> implements RetryExecutor<T, Status<T>> {
             T callResult = callable.call();
 
             boolean shouldRetryOnThisResult = config.shouldRetryOnValue() && (
-                            ( config.getValuesToExpect() != null && !isOneOfValuesToExpect( callResult ) )
-                                            || isOneOfValuesToRetryOn( callResult ) );
+                    (config.getValuesToExpect() != null && !isOneOfValuesToExpect(callResult))
+                            || isOneOfValuesToRetryOn(callResult));
             if (shouldRetryOnThisResult) {
                 attemptStatus.setSuccessful(false);
             } else {
@@ -154,11 +155,11 @@ public class CallExecutor<T> implements RetryExecutor<T, Status<T>> {
         return attemptStatus;
     }
 
-    private boolean isOneOfValuesToExpect( T callResult ) {
-        Object[] valuesToExpect = config.getValuesToExpect();
-        if ( valuesToExpect != null ) {
-            for ( Object o : valuesToExpect ) {
-                if ( o.equals( callResult ) ) {
+    private boolean isOneOfValuesToExpect(T callResult) {
+        Collection<Object> valuesToExpect = config.getValuesToExpect();
+        if (valuesToExpect != null) {
+            for (Object o : valuesToExpect) {
+                if (o.equals(callResult)) {
                     return true;
                 }
             }
@@ -166,13 +167,11 @@ public class CallExecutor<T> implements RetryExecutor<T, Status<T>> {
         return false;
     }
 
-    private boolean isOneOfValuesToRetryOn( T callResult )
-    {
-        if ( config.getValuesToRetryOn() != null ) {
-            for ( Object o : config.getValuesToRetryOn() )
-            {
-                if ( o.equals( callResult ) )
-                {
+    private boolean isOneOfValuesToRetryOn(T callResult) {
+        Collection<Object> valuesToRetryOn = config.getValuesToRetryOn();
+        if (valuesToRetryOn != null) {
+            for (Object o : valuesToRetryOn) {
+                if (o.equals(callResult)) {
                     return true;
                 }
             }

--- a/src/main/java/com/evanlennick/retry4j/config/RetryConfig.java
+++ b/src/main/java/com/evanlennick/retry4j/config/RetryConfig.java
@@ -3,7 +3,7 @@ package com.evanlennick.retry4j.config;
 import com.evanlennick.retry4j.backoff.BackoffStrategy;
 
 import java.time.Duration;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -15,8 +15,8 @@ public class RetryConfig {
     private final Integer maxNumberOfTries;
     private final Duration delayBetweenRetries;
     private final BackoffStrategy backoffStrategy;
-    private final Object[] valuesToRetryOn;
-    private final Object[] valuesToExpect;
+    private final Collection<Object> valuesToRetryOn;
+    private final Collection<Object> valuesToExpect;
     private final boolean retryOnValue;
     private final Function<Exception, Boolean> customRetryOnLogic;
     private final boolean retryOnCausedBy;
@@ -24,7 +24,7 @@ public class RetryConfig {
     RetryConfig(boolean retryOnAnyException, Set<Class<? extends Exception>> retryOnSpecificExceptions,
                 Set<Class<? extends Exception>> retryOnAnyExceptionExcluding, Integer maxNumberOfTries,
                 Duration delayBetweenRetries, BackoffStrategy backoffStrategy,
-                Object[] valuesToRetryOn, Object[] valuesToExpect,
+                Collection<Object> valuesToRetryOn, Collection<Object> valuesToExpect,
                 boolean retryOnValue, Function<Exception, Boolean> customRetryOnLogic, boolean retryOnCausedBy) {
         this.retryOnAnyException = retryOnAnyException;
         this.retryOnSpecificExceptions = retryOnSpecificExceptions;
@@ -39,11 +39,11 @@ public class RetryConfig {
         this.retryOnCausedBy = retryOnCausedBy;
     }
 
-    public Object[] getValuesToRetryOn() {
+    public Collection<Object> getValuesToRetryOn() {
         return valuesToRetryOn;
     }
 
-    public Object[] getValuesToExpect() {
+    public Collection<Object> getValuesToExpect() {
         return valuesToExpect;
     }
 
@@ -92,7 +92,8 @@ public class RetryConfig {
         sb.append(", maxNumberOfTries=").append(maxNumberOfTries);
         sb.append(", delayBetweenRetries=").append(delayBetweenRetries);
         sb.append(", backoffStrategy=").append(backoffStrategy);
-        sb.append(", valuesToRetryOn=").append( valuesToRetryOn == null ? "null" : Arrays.asList( valuesToRetryOn ));
+        sb.append(", valuesToRetryOn=").append(valuesToRetryOn);
+        sb.append(", valuesToExpect=").append(valuesToExpect);
         sb.append(", retryOnValue=").append(retryOnValue);
         sb.append(", customRetryOnLogic=").append(customRetryOnLogic);
         sb.append('}');

--- a/src/main/java/com/evanlennick/retry4j/config/RetryConfig.java
+++ b/src/main/java/com/evanlennick/retry4j/config/RetryConfig.java
@@ -3,6 +3,7 @@ package com.evanlennick.retry4j.config;
 import com.evanlennick.retry4j.backoff.BackoffStrategy;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -14,14 +15,16 @@ public class RetryConfig {
     private final Integer maxNumberOfTries;
     private final Duration delayBetweenRetries;
     private final BackoffStrategy backoffStrategy;
-    private final Object valueToRetryOn;
+    private final Object[] valuesToRetryOn;
+    private final Object[] valuesToExpect;
     private final boolean retryOnValue;
     private final Function<Exception, Boolean> customRetryOnLogic;
     private final boolean retryOnCausedBy;
 
     RetryConfig(boolean retryOnAnyException, Set<Class<? extends Exception>> retryOnSpecificExceptions,
                 Set<Class<? extends Exception>> retryOnAnyExceptionExcluding, Integer maxNumberOfTries,
-                Duration delayBetweenRetries, BackoffStrategy backoffStrategy, Object valueToRetryOn,
+                Duration delayBetweenRetries, BackoffStrategy backoffStrategy,
+                Object[] valuesToRetryOn, Object[] valuesToExpect,
                 boolean retryOnValue, Function<Exception, Boolean> customRetryOnLogic, boolean retryOnCausedBy) {
         this.retryOnAnyException = retryOnAnyException;
         this.retryOnSpecificExceptions = retryOnSpecificExceptions;
@@ -29,14 +32,19 @@ public class RetryConfig {
         this.maxNumberOfTries = maxNumberOfTries;
         this.delayBetweenRetries = delayBetweenRetries;
         this.backoffStrategy = backoffStrategy;
-        this.valueToRetryOn = valueToRetryOn;
+        this.valuesToRetryOn = valuesToRetryOn;
+        this.valuesToExpect = valuesToExpect;
         this.retryOnValue = retryOnValue;
         this.customRetryOnLogic = customRetryOnLogic;
         this.retryOnCausedBy = retryOnCausedBy;
     }
 
-    public Object getValueToRetryOn() {
-        return valueToRetryOn;
+    public Object[] getValuesToRetryOn() {
+        return valuesToRetryOn;
+    }
+
+    public Object[] getValuesToExpect() {
+        return valuesToExpect;
     }
 
     public boolean shouldRetryOnValue() {
@@ -84,7 +92,7 @@ public class RetryConfig {
         sb.append(", maxNumberOfTries=").append(maxNumberOfTries);
         sb.append(", delayBetweenRetries=").append(delayBetweenRetries);
         sb.append(", backoffStrategy=").append(backoffStrategy);
-        sb.append(", valueToRetryOn=").append(valueToRetryOn);
+        sb.append(", valuesToRetryOn=").append( valuesToRetryOn == null ? "null" : Arrays.asList( valuesToRetryOn ));
         sb.append(", retryOnValue=").append(retryOnValue);
         sb.append(", customRetryOnLogic=").append(customRetryOnLogic);
         sb.append('}');

--- a/src/main/java/com/evanlennick/retry4j/config/RetryConfigBuilder.java
+++ b/src/main/java/com/evanlennick/retry4j/config/RetryConfigBuilder.java
@@ -11,9 +11,7 @@ import com.evanlennick.retry4j.exception.InvalidRetryConfigException;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -46,8 +44,8 @@ public class RetryConfigBuilder {
     private Integer maxNumberOfTries;
     private Duration delayBetweenRetries;
     private BackoffStrategy backoffStrategy;
-    private Object[] valuesToRetryOn;
-    private Object[] valuesToExpect;
+    private Collection<Object> valuesToRetryOn;
+    private Collection<Object> valuesToExpect;
     private Boolean retryOnValue = false;
     private Function<Exception, Boolean> customRetryOnLogic;
     private boolean retryOnCausedBy;
@@ -118,7 +116,7 @@ public class RetryConfigBuilder {
 
     public final RetryConfigBuilder retryOnReturnValue(Object value) {
         retryOnValue = true;
-        valuesToRetryOn = new Object[] { value };
+        valuesToRetryOn = Arrays.asList(value);
 
         return this;
     }
@@ -126,7 +124,7 @@ public class RetryConfigBuilder {
     @SafeVarargs
     public final RetryConfigBuilder retryOnReturnValues(Object... values) {
         retryOnValue = true;
-        valuesToRetryOn = values;
+        valuesToRetryOn = Arrays.asList(values);
 
         return this;
     }
@@ -134,7 +132,7 @@ public class RetryConfigBuilder {
     @SafeVarargs
     public final RetryConfigBuilder retryOnReturnValuesExcluding(Object... values) {
         retryOnValue = true;
-        valuesToExpect = values;
+        valuesToExpect = Arrays.asList(values);
 
         return this;
     }
@@ -227,11 +225,11 @@ public class RetryConfigBuilder {
     }
 
     public RetryConfig build() {
-        RetryConfig retryConfig = new RetryConfig( retryOnAnyException, retryOnSpecificExceptions,
-                                                   retryOnAnyExceptionExcluding, maxNumberOfTries,
-                                                   delayBetweenRetries, backoffStrategy, valuesToRetryOn,
-                                                   valuesToExpect,
-                                                   retryOnValue, customRetryOnLogic, retryOnCausedBy);
+        RetryConfig retryConfig = new RetryConfig(retryOnAnyException, retryOnSpecificExceptions,
+                retryOnAnyExceptionExcluding, maxNumberOfTries,
+                delayBetweenRetries, backoffStrategy, valuesToRetryOn,
+                valuesToExpect,
+                retryOnValue, customRetryOnLogic, retryOnCausedBy);
 
         validateConfig(retryConfig);
 

--- a/src/main/java/com/evanlennick/retry4j/config/RetryConfigBuilder.java
+++ b/src/main/java/com/evanlennick/retry4j/config/RetryConfigBuilder.java
@@ -46,7 +46,8 @@ public class RetryConfigBuilder {
     private Integer maxNumberOfTries;
     private Duration delayBetweenRetries;
     private BackoffStrategy backoffStrategy;
-    private Object valueToRetryOn;
+    private Object[] valuesToRetryOn;
+    private Object[] valuesToExpect;
     private Boolean retryOnValue = false;
     private Function<Exception, Boolean> customRetryOnLogic;
     private boolean retryOnCausedBy;
@@ -117,7 +118,23 @@ public class RetryConfigBuilder {
 
     public final RetryConfigBuilder retryOnReturnValue(Object value) {
         retryOnValue = true;
-        valueToRetryOn = value;
+        valuesToRetryOn = new Object[] { value };
+
+        return this;
+    }
+
+    @SafeVarargs
+    public final RetryConfigBuilder retryOnReturnValues(Object... values) {
+        retryOnValue = true;
+        valuesToRetryOn = values;
+
+        return this;
+    }
+
+    @SafeVarargs
+    public final RetryConfigBuilder retryOnReturnValuesExcluding(Object... values) {
+        retryOnValue = true;
+        valuesToExpect = values;
 
         return this;
     }
@@ -210,10 +227,11 @@ public class RetryConfigBuilder {
     }
 
     public RetryConfig build() {
-        RetryConfig retryConfig = new RetryConfig(retryOnAnyException, retryOnSpecificExceptions,
-                retryOnAnyExceptionExcluding, maxNumberOfTries,
-                delayBetweenRetries, backoffStrategy, valueToRetryOn,
-                retryOnValue, customRetryOnLogic, retryOnCausedBy);
+        RetryConfig retryConfig = new RetryConfig( retryOnAnyException, retryOnSpecificExceptions,
+                                                   retryOnAnyExceptionExcluding, maxNumberOfTries,
+                                                   delayBetweenRetries, backoffStrategy, valuesToRetryOn,
+                                                   valuesToExpect,
+                                                   retryOnValue, customRetryOnLogic, retryOnCausedBy);
 
         validateConfig(retryConfig);
 

--- a/src/test/java/com/evanlennick/retry4j/CallExecutorTest_RetryOnValueTest.java
+++ b/src/test/java/com/evanlennick/retry4j/CallExecutorTest_RetryOnValueTest.java
@@ -117,6 +117,38 @@ public class CallExecutorTest_RetryOnValueTest {
     }
 
     @Test
+    public void verifyRetryOnReturnValuesExcluding_shouldRetry() {
+        Callable<RetryOnValueTestObject> callable
+                        = () -> new RetryOnValueTestObject("500 ERROR");
+
+        RetryConfig config = retryConfigBuilder
+                        .retryOnAnyException()
+                        .retryOnReturnValuesExcluding(new RetryOnValueTestObject("200 OK"))
+                        .withDelayBetweenTries(Duration.ZERO)
+                        .withMaxNumberOfTries(3)
+                        .withFixedBackoff()
+                        .build();
+
+        assertRetryOccurs(config, callable, 3);
+    }
+
+    @Test
+    public void verifyRetryOnReturnValuesExcluding_shouldNotRetry() {
+        Callable<RetryOnValueTestObject> callable
+                        = () -> new RetryOnValueTestObject("201 CREATED");
+
+        RetryConfig config = retryConfigBuilder
+                        .retryOnAnyException()
+                        .retryOnReturnValuesExcluding(new RetryOnValueTestObject("200 OK"),new RetryOnValueTestObject("201 CREATED"))
+                        .withDelayBetweenTries(Duration.ZERO)
+                        .withMaxNumberOfTries(3)
+                        .withFixedBackoff()
+                        .build();
+
+        assertRetryDoesNotOccur(config, callable);
+    }
+
+    @Test
     public void verifyRetryOnValueAndExceptionInSameCall() {
         final Random random = new Random();
         Callable<Boolean> callable = () -> {

--- a/src/test/java/com/evanlennick/retry4j/CallExecutorTest_RetryOnValueTest.java
+++ b/src/test/java/com/evanlennick/retry4j/CallExecutorTest_RetryOnValueTest.java
@@ -117,6 +117,23 @@ public class CallExecutorTest_RetryOnValueTest {
     }
 
     @Test
+    public void verifyRetryOnReturnValues_shouldRetry() {
+        Callable<RetryOnValueTestObject> callable
+                        = () -> new RetryOnValueTestObject("500 ERROR");
+
+        RetryConfig config = retryConfigBuilder
+                        .retryOnAnyException()
+                        .retryOnReturnValues(new RetryOnValueTestObject("500 ERROR"),
+                                             new RetryOnValueTestObject("501 NOT IMPLEMENTED"))
+                        .withDelayBetweenTries(Duration.ZERO)
+                        .withMaxNumberOfTries(3)
+                        .withFixedBackoff()
+                        .build();
+
+        assertRetryOccurs(config, callable, 3);
+    }
+
+    @Test
     public void verifyRetryOnReturnValuesExcluding_shouldRetry() {
         Callable<RetryOnValueTestObject> callable
                         = () -> new RetryOnValueTestObject("500 ERROR");


### PR DESCRIPTION
I need two more APIs in RetryConfigBuilder. The retryOnReturnValues takes an array of retriable values. The retryOnReturnValuesExcluding handles the case where I only expect certain return value(s). E.g., only "200" for a REST call and retry for any other status codes.
Can anyone help review this? 